### PR TITLE
feat | sprint3 | LC-127 | Request Header (JWT) 정보 축소 (userId, employeeId) | SHUN

### DIFF
--- a/src/main/java/com/deefacto/alim_service/alertNoti/controller/SseController.java
+++ b/src/main/java/com/deefacto/alim_service/alertNoti/controller/SseController.java
@@ -1,6 +1,8 @@
 package com.deefacto.alim_service.alertNoti.controller;
 
+import com.deefacto.alim_service.alertNoti.domain.dto.UserCacheDto;
 import com.deefacto.alim_service.alertNoti.service.SseService;
+import com.deefacto.alim_service.alertNoti.service.UserRedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -14,14 +16,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SseController {
 
     private final SseService sseService;
+    private final UserRedisService userRedisService;
 
     @GetMapping("/subscribe")
     public SseEmitter subscribe(@RequestHeader("X-Employee-Id") String employeeId,
                                 @RequestHeader("X-User-Id") Long userId,
-                                @RequestHeader("X-Role") String userRole,
-                                @RequestHeader("X-Shift") String userShift,
                                 @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId) {
-        return sseService.subscribe(employeeId, userRole, userShift, lastEventId);
+        UserCacheDto userInfo = userRedisService.getUserInfo(employeeId);
+        return sseService.subscribe(employeeId, userInfo.getScope(), userInfo.getShift(), lastEventId);
     }
 }
 

--- a/src/main/java/com/deefacto/alim_service/alertNoti/domain/dto/UserCacheDto.java
+++ b/src/main/java/com/deefacto/alim_service/alertNoti/domain/dto/UserCacheDto.java
@@ -1,0 +1,25 @@
+package com.deefacto.alim_service.alertNoti.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserCacheDto {
+    // 고유식별번호
+    private Long id;
+    // 사번
+    private String employeeId;
+    // 이름
+    private String name;
+    // 권한
+    private String role;
+    // 구역 범위
+    private String scope;
+    // 근무시간
+    private String shift;
+}

--- a/src/main/java/com/deefacto/alim_service/alertNoti/service/AlertRedisService.java
+++ b/src/main/java/com/deefacto/alim_service/alertNoti/service/AlertRedisService.java
@@ -21,11 +21,11 @@ public class AlertRedisService {
 
     public void saveAlert(Alert alert) {
         String key = KEY_PREFIX + alert.getId();
-//        redisTemplate.opsForValue().set(key, alert, Duration.ofHours(1));
         redisTemplate.opsForValue().set(key, alert, Duration.ofMinutes(5));
 
     }
 
+    // 누락 메시지 재전송
     public List<Alert> getAlertsAfter(String lastEventId) {
         Set<String> keys = redisTemplate.keys(KEY_PREFIX + "*");
         if (keys == null || keys.isEmpty()) {

--- a/src/main/java/com/deefacto/alim_service/alertNoti/service/UserRedisService.java
+++ b/src/main/java/com/deefacto/alim_service/alertNoti/service/UserRedisService.java
@@ -1,0 +1,31 @@
+package com.deefacto.alim_service.alertNoti.service;
+
+import com.deefacto.alim_service.alertNoti.domain.dto.UserCacheDto;
+import com.deefacto.alim_service.common.exception.CustomException;
+import com.deefacto.alim_service.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserRedisService {
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String KEY_PREFIX = "user:";
+
+    public UserCacheDto getUserInfo(String employeeId) {
+        String key = KEY_PREFIX + employeeId;
+        // 캐스팅 없이 바로 UserCacheDto 타입으로 반환됩니다.
+        Object obj = redisTemplate.opsForValue().get(key);
+        UserCacheDto userInfo = objectMapper.convertValue(obj, UserCacheDto.class);
+        if(userInfo == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        return userInfo;
+    }
+
+}

--- a/src/main/java/com/deefacto/alim_service/common/config/RedisConfig.java
+++ b/src/main/java/com/deefacto/alim_service/common/config/RedisConfig.java
@@ -57,16 +57,5 @@ public class RedisConfig {
         template.afterPropertiesSet();
         return template;
     }
-
-
-//    // 문자열 전용 RedisTemplate (필요 시 활성화)
-//    @Bean
-//    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
-//        RedisTemplate<String, String> template = new RedisTemplate<>();
-//        template.setConnectionFactory(connectionFactory);
-//        template.setKeySerializer(new StringRedisSerializer());
-//        template.setValueSerializer(new StringRedisSerializer());
-//        return template;
-//    }
 }
 

--- a/src/main/java/com/deefacto/alim_service/commonNoti/controller/NotificationController.java
+++ b/src/main/java/com/deefacto/alim_service/commonNoti/controller/NotificationController.java
@@ -20,11 +20,10 @@ public class NotificationController {
     @GetMapping("/list")
     public ApiResponseDto<Page<NotificationReadDTO>> getNotificationsForUser(@RequestHeader("X-Employee-Id") String employeeId,
                                                @RequestHeader("X-User-Id") Long userId,
-                                                @RequestHeader("X-Role") String userRole,
-                                                @RequestHeader("X-Shift") String userShift,
                                                 @RequestParam(required = false) Boolean isRead,
                                                 @RequestParam(required = false) Boolean isFlagged,
-                                                Pageable pageable) {
+                                                Pageable pageable
+    ) {
         Page<NotificationReadDTO> notificationList = notificationService.getNotificationsForUser(userId, isRead, isFlagged, pageable);
         return ApiResponseDto.createOk(notificationList);
     }
@@ -33,9 +32,8 @@ public class NotificationController {
     // "noti_count": 21
     @GetMapping("/count")
     public ApiResponseDto<Integer> getUnreadNotiCountForUser(@RequestHeader("X-Employee-Id") String employeeId,
-                                            @RequestHeader("X-User-Id") Long userId,
-                                           @RequestHeader("X-Role") String userRole,
-                                           @RequestHeader("X-Shift") String userShift) {
+                                                            @RequestHeader("X-User-Id") Long userId
+    ) {
         Integer notiCount = notificationService.getUnreadNotiCountForUser(userId);
         return ApiResponseDto.createOk(notiCount);
     }
@@ -44,9 +42,8 @@ public class NotificationController {
     @GetMapping("/read/{notiId}")
     public ApiResponseDto<Integer> updateReadStatus(@RequestHeader("X-Employee-Id") String employeeId,
                                                     @RequestHeader("X-User-Id") Long userId,
-                                                    @RequestHeader("X-Role") String userRole,
-                                                    @RequestHeader("X-Shift") String userShift,
-                                                    @PathVariable Long notiId) {
+                                                    @PathVariable Long notiId
+    ) {
 
         int update = notificationService.updateReadStatus(userId, notiId);
         return ApiResponseDto.createOk(update);
@@ -55,9 +52,8 @@ public class NotificationController {
     // 알림 일괄 읽음 처리
     @GetMapping("/read/all")
     public ApiResponseDto<Integer> updateAllReadStatus(@RequestHeader("X-Employee-Id") String employeeId,
-                                              @RequestHeader("X-User-Id") Long userId,
-                                               @RequestHeader("X-Role") String userRole,
-                                               @RequestHeader("X-Shift") String userShift) {
+                                              @RequestHeader("X-User-Id") Long userId
+    ) {
         int update = notificationService.updateAllReadStatus(userId);
         return ApiResponseDto.createOk(update);
     }
@@ -66,9 +62,8 @@ public class NotificationController {
     @GetMapping("/favorite/{notiId}")
     public ApiResponseDto<Integer> toggleNotificationFlag(@RequestHeader("X-Employee-Id") String employeeId,
                                                           @RequestHeader("X-User-Id") Long userId,
-                                                          @RequestHeader("X-Role") String userRole,
-                                                          @RequestHeader("X-Shift") String userShift,
-                                                          @PathVariable Long notiId) {
+                                                          @PathVariable Long notiId
+    ) {
         int updated = notificationService.toggleNotificationFlag(userId, notiId);
         return ApiResponseDto.createOk(updated);
     }

--- a/src/main/java/com/deefacto/alim_service/commonNoti/service/NotificationUserService.java
+++ b/src/main/java/com/deefacto/alim_service/commonNoti/service/NotificationUserService.java
@@ -72,9 +72,9 @@ public class NotificationUserService {
         int hour = notification.getTimestamp().getHour();
         String shift = "None";
         if(hour >= 7 && hour < 19) {
-            shift = "A";
+            shift = "DAY";
         } else if (hour >= 19 || hour < 7){
-            shift = "B";
+            shift = "NIGHT";
         }
 
         Notification result = notificationRepository.save(notification);


### PR DESCRIPTION
- 누락 메시지 재전송 로직 보완
  - 기존: 이전 5분간 Redis에 적재된 알림 로그를 권한 구분없이 모두 전송
  - 현재: 적재된 로그를 권한에 따라 전송
- reqeust Header 전송 정보 축소
  - 기존: userId, employeeId, shift, role
  - 현재: userId, employeeId
  - User 측에서 Redis에 적재한 유저 정보 이용하는 방법으로 수정.
- shift 포맷 변경
  - 기존: A, B
  - 현재: DAY, NIGHT